### PR TITLE
feat(core): set status to ready after excuting `set`

### DIFF
--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -106,14 +106,14 @@ The primary class for creating and managing a synchronized state.
 
 #### Methods
 
-| Method              | Signature                                               | Description                                                                                                                           |
-| ------------------- | ------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------- |
-| `get()`             | `(): T`                                                 | Synchronously returns the current state.                                                                                              |
-| `set()`             | `(value: T): Promise<void>`                             | Asynchronously sets a new state, broadcasts it to other contexts, and persists it if `persist` is enabled.                            |
-| `subscribe()`       | `(callback: (value: T) => void): () => void`            | Subscribes to state changes. The callback receives the new state. Returns an `unsubscribe` function.                                  |
-| `subscribeStatus()` | `(callback: (status: StoreStatus) => void): () => void` | Subscribes to store status changes. The callback receives the new status. Returns an `unsubscribe` function.                          |
-| `destroy()`         | `(): void`                                              | Closes the `BroadcastChannel` and `IndexedDB` connections and cleans up all subscribers. The store instance cannot be used afterward. |
-| `reset()`           | `(): Promise<void>`                                     | Resets the state to its `initial` value and broadcasts the change.                                                                    |
+| Method              | Signature                                               | Description                                                                                                                                                              |
+| ------------------- | ------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `get()`             | `(): T`                                                 | Synchronously returns the current state.                                                                                                                                 |
+| `set()`             | `(value: T): void`                                      | Sets a new state, broadcasts it to other contexts, and persists it if `persist` is enabled. The method itself is synchronous, but persistence happens in the background. |
+| `subscribe()`       | `(callback: (value: T) => void): () => void`            | Subscribes to state changes. The callback receives the new state. Returns an `unsubscribe` function.                                                                     |
+| `subscribeStatus()` | `(callback: (status: StoreStatus) => void): () => void` | Subscribes to store status changes. The callback receives the new status. Returns an `unsubscribe` function.                                                             |
+| `destroy()`         | `(): void`                                              | Closes the `BroadcastChannel` and `IndexedDB` connections and cleans up all subscribers. The store instance cannot be used afterward.                                    |
+| `reset()`           | `(): Promise<void>`                                     | Resets the state to its `initial` value and broadcasts the change.                                                                                                       |
 
 ## 🚀 Example Usage
 


### PR DESCRIPTION
## Description

 set status to ready after excuting `set` to avoid race condition

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [X] New feature (non-breaking change which adds functionality)
- [X] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

- [X] console the status after set

## Browser Compatibility

This library relies on `BroadcastChannel` and `IndexedDB` APIs. Please ensure your changes are compatible with modern browsers. Note that Internet Explorer does not support `BroadcastChannel` and has limited `IndexedDB` support, and this library is not intended for use in Internet Explorer.

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass successfully with my changes
- [X] Any dependent changes have been merged and published in downstream modules
