### PR TITLE
feat(core): use the Web Locks API for leader election

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
           cache: 'pnpm'
 
       - name: Install dependencies

--- a/package.json
+++ b/package.json
@@ -89,7 +89,7 @@
     "svelte-eslint-parser": "^1.3.0",
     "ts-node": "^10.9.2",
     "tsup": "^8.0.0",
-    "typescript": "^5.0.0",
+    "typescript": "^5.9.3",
     "typescript-eslint": "^8.35.1",
     "vite": "^6.0.0",
     "vitest": "^3.2.4",

--- a/packages/core/src/ChannelState.test.ts
+++ b/packages/core/src/ChannelState.test.ts
@@ -35,6 +35,138 @@ const mockIndexedDB = {
   })),
 }
 
+interface MockLockManager {
+  readonly request: ReturnType<typeof vi.fn>
+}
+
+interface CreateMockLockManagerOptions {
+  initialLockAvailable: boolean
+}
+
+interface QueuedMockLockRequest {
+  readonly name: string
+  readonly callback: LockGrantedCallback<unknown>
+  readonly resolve: (value: unknown) => void
+  readonly reject: (reason?: unknown) => void
+  readonly signal: AbortSignal | undefined
+}
+
+async function flushPromises(): Promise<void> {
+  await Promise.resolve()
+  await Promise.resolve()
+}
+
+async function flushWebLockPromotion(): Promise<void> {
+  await flushPromises()
+  await flushPromises()
+  await flushPromises()
+}
+
+function setNavigatorLocks(locks: MockLockManager | undefined): void {
+  Object.defineProperty(globalThis.navigator, 'locks', {
+    configurable: true,
+    value: locks,
+  })
+}
+
+function createAbortError(): DOMException {
+  return new DOMException('Aborted', 'AbortError')
+}
+
+function createMockLockManager(
+  options: CreateMockLockManagerOptions,
+): MockLockManager {
+  let lockAvailable = options.initialLockAvailable
+  const queuedRequests: QueuedMockLockRequest[] = []
+
+  function grantNextQueuedLock(): void {
+    const queuedRequest = queuedRequests.shift()
+
+    if (!queuedRequest) {
+      lockAvailable = true
+      return
+    }
+
+    if (queuedRequest.signal?.aborted) {
+      queuedRequest.reject(createAbortError())
+      grantNextQueuedLock()
+      return
+    }
+
+    void grantLock(queuedRequest.name, queuedRequest.callback).then(
+      queuedRequest.resolve,
+      queuedRequest.reject,
+    )
+  }
+
+  async function grantLock<T>(
+    name: string,
+    callback: LockGrantedCallback<T>,
+  ): Promise<T> {
+    lockAvailable = false
+
+    try {
+      return await callback({ name, mode: 'exclusive' })
+    } finally {
+      grantNextQueuedLock()
+    }
+  }
+
+  async function enqueueLockRequest<T>(
+    name: string,
+    callback: LockGrantedCallback<T>,
+    signal: AbortSignal | undefined,
+  ): Promise<T> {
+    if (signal?.aborted) {
+      throw createAbortError()
+    }
+
+    return new Promise<T>((resolve, reject) => {
+      function handleAbort(): void {
+        reject(createAbortError())
+      }
+
+      signal?.addEventListener('abort', handleAbort, { once: true })
+
+      queuedRequests.push({
+        name,
+        callback,
+        resolve: resolve as (value: unknown) => void,
+        reject,
+        signal,
+      })
+    })
+  }
+
+  async function request<T>(
+    name: string,
+    requestOptions: LockOptions,
+    callback: LockGrantedCallback<T>,
+  ): Promise<T> {
+    if (requestOptions.signal?.aborted) {
+      throw createAbortError()
+    }
+
+    if (requestOptions.ifAvailable) {
+      if (!lockAvailable) {
+        return callback(null)
+      }
+
+      return grantLock(name, callback)
+    }
+
+    if (lockAvailable) {
+      return grantLock(name, callback)
+    }
+
+    return enqueueLockRequest(name, callback, requestOptions.signal)
+  }
+
+  return {
+    request: vi.fn(request),
+  }
+}
+
 Object.defineProperty(global, 'indexedDB', {
   writable: true,
   value: mockIndexedDB,
@@ -44,6 +176,7 @@ describe('ChannelStore', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     vi.useFakeTimers()
+    setNavigatorLocks(undefined)
     mockPostMessage.mockRestore()
     mockAddEventListener.mockRestore()
     mockRemoveEventListener.mockRestore()
@@ -62,6 +195,7 @@ describe('ChannelStore', () => {
   })
 
   afterEach(() => {
+    setNavigatorLocks(undefined)
     vi.useRealTimers()
   })
 
@@ -69,6 +203,231 @@ describe('ChannelStore', () => {
     const store = new ChannelStore({ name: 'test-store', initial: 0 })
     expect(store.get()).toBe(0)
     expect(mockIndexedDB.open).not.toHaveBeenCalled()
+  })
+
+  it('should skip initial state request when Web Locks prove this is the only memory-only store', async () => {
+    const lockManager = createMockLockManager({ initialLockAvailable: true })
+    setNavigatorLocks(lockManager)
+
+    const store = new ChannelStore({
+      name: 'test-store',
+      initial: 0,
+      persist: false,
+    })
+
+    await flushPromises()
+
+    expect(store.status).toBe('ready')
+    expect(mockPostMessage).not.toHaveBeenCalledWith({
+      type: 'REQUEST_INIT_STATE',
+      senderId: expect.any(String) as string,
+    })
+    expect(lockManager.request).toHaveBeenCalledWith(
+      'channel-state__test-store__leader',
+      { ifAvailable: true },
+      expect.any(Function),
+    )
+
+    store.destroy()
+  })
+
+  it('should request initial state when Web Locks indicate another memory-only store exists', async () => {
+    const lockManager = createMockLockManager({ initialLockAvailable: false })
+    setNavigatorLocks(lockManager)
+
+    const store = new ChannelStore({
+      name: 'test-store',
+      initial: 0,
+      persist: false,
+    })
+
+    await flushPromises()
+
+    expect(mockPostMessage).toHaveBeenCalledWith({
+      type: 'REQUEST_INIT_STATE',
+      senderId: expect.any(String) as string,
+    })
+    // 1st time for checking if lock is available
+    // 2nd time for queuing
+    expect(lockManager.request).toHaveBeenCalledTimes(2)
+
+    const messageEvent = new MessageEvent('message', {
+      data: {
+        type: 'RESPONSE_INIT_STATE',
+        payload: 10,
+        senderId: 'some-other-id',
+      },
+    })
+    const eventHandler = mockAddEventListener.mock.calls[0][1] as EventListener
+
+    eventHandler(messageEvent)
+    vi.runAllTimers()
+
+    expect(store.status).toBe('ready')
+    expect(store.get()).toBe(10)
+
+    store.destroy()
+  })
+
+  it('should only let the memory-only Web Locks leader answer initial state requests', async () => {
+    // current tab is follower
+    const lockManager = createMockLockManager({ initialLockAvailable: false })
+    setNavigatorLocks(lockManager)
+
+    const store = new ChannelStore({
+      name: 'test-store',
+      initial: 0,
+      persist: false,
+    })
+
+    await flushPromises()
+
+    const eventHandler = mockAddEventListener.mock.calls[0][1] as EventListener
+
+    // initalize current tab
+    eventHandler(
+      new MessageEvent('message', {
+        data: {
+          type: 'RESPONSE_INIT_STATE',
+          payload: 10,
+          senderId: 'leader-id',
+        },
+      }),
+    )
+
+    expect(store.status).toBe('ready')
+    expect(store.get()).toBe(10)
+
+    mockPostMessage.mockClear()
+
+    eventHandler(
+      new MessageEvent('message', {
+        data: {
+          type: 'REQUEST_INIT_STATE',
+          senderId: 'new-tab-id',
+        },
+      }),
+    )
+
+    // current tab ignores the request because it's not the leader
+    expect(mockPostMessage).not.toHaveBeenCalledWith({
+      type: 'RESPONSE_INIT_STATE',
+      payload: 10,
+      senderId: expect.any(String) as string,
+    })
+
+    store.destroy()
+  })
+
+  it('should let the memory-only Web Locks leader answer initial state requests', async () => {
+    const lockManager = createMockLockManager({ initialLockAvailable: true })
+    setNavigatorLocks(lockManager)
+
+    const store = new ChannelStore({
+      name: 'test-store',
+      initial: 0,
+      persist: false,
+    })
+
+    await flushPromises()
+    store.set(10)
+    mockPostMessage.mockClear()
+
+    const eventHandler = mockAddEventListener.mock.calls[0][1] as EventListener
+
+    eventHandler(
+      new MessageEvent('message', {
+        data: {
+          type: 'REQUEST_INIT_STATE',
+          senderId: 'new-tab-id',
+        },
+      }),
+    )
+
+    expect(mockPostMessage).toHaveBeenCalledWith({
+      type: 'RESPONSE_INIT_STATE',
+      payload: 10,
+      senderId: expect.any(String) as string,
+    })
+
+    store.destroy()
+  })
+
+  it('should appoint a queued memory-only store as the new Web Locks leader when the current leader is gone', async () => {
+    const lockManager = createMockLockManager({ initialLockAvailable: true })
+    setNavigatorLocks(lockManager)
+
+    const leaderStore = new ChannelStore({
+      name: 'test-store',
+      initial: 0,
+      persist: false,
+    })
+
+    await flushPromises()
+    leaderStore.set(10)
+
+    const queuedStore = new ChannelStore({
+      name: 'test-store',
+      initial: 0,
+      persist: false,
+    })
+
+    await flushPromises()
+
+    const queuedStoreEventHandler = mockAddEventListener.mock
+      .calls[1][1] as EventListener
+
+    queuedStoreEventHandler(
+      new MessageEvent('message', {
+        data: {
+          type: 'RESPONSE_INIT_STATE',
+          payload: 10,
+          senderId: 'leader-id',
+        },
+      }),
+    )
+
+    expect(queuedStore.status).toBe('ready')
+    expect(queuedStore.get()).toBe(10)
+
+    mockPostMessage.mockClear()
+
+    queuedStoreEventHandler(
+      new MessageEvent('message', {
+        data: {
+          type: 'REQUEST_INIT_STATE',
+          senderId: 'new-tab-before-promotion-id',
+        },
+      }),
+    )
+
+    expect(mockPostMessage).not.toHaveBeenCalledWith({
+      type: 'RESPONSE_INIT_STATE',
+      payload: 10,
+      senderId: expect.any(String) as string,
+    })
+
+    leaderStore.destroy()
+    await flushWebLockPromotion()
+    mockPostMessage.mockClear()
+
+    queuedStoreEventHandler(
+      new MessageEvent('message', {
+        data: {
+          type: 'REQUEST_INIT_STATE',
+          senderId: 'new-tab-after-promotion-id',
+        },
+      }),
+    )
+
+    // only leader respond to initial state requests
+    expect(mockPostMessage).toHaveBeenCalledWith({
+      type: 'RESPONSE_INIT_STATE',
+      payload: 10,
+      senderId: expect.any(String) as string,
+    })
+
+    queuedStore.destroy()
   })
 
   it('should update value and notify subscribers', () => {

--- a/packages/core/src/ChannelState.ts
+++ b/packages/core/src/ChannelState.ts
@@ -15,26 +15,33 @@
  */
 
 /**
+ * Represents a message sent between stores.
+ * @template T The type of the payload.
+ * @remarks This interface is used for both sending and receiving messages between stores.
+ */
+export type StoreBroadcastMessage<T> =
+  | {
+      type: 'REQUEST_INIT_STATE'
+      senderId: string
+    }
+  | {
+      type: 'RESPONSE_INIT_STATE'
+      senderId: string
+      payload: T
+    }
+  | {
+      type: 'STATE_UPDATE'
+      senderId: string
+      payload: T
+    }
+
+/**
  * Represents the types of messages that can be sent between stores.
  * - 'REQUEST_INIT_STATE': A request from a new store instance asking for the current state.
  * - 'RESPONSE_INIT_STATE': A response from an existing store, providing its state to the new instance.
  * - 'STATE_UPDATE': A regular state update broadcast to all other stores.
  */
-export type StoreBroadcastMessageType =
-  | 'REQUEST_INIT_STATE'
-  | 'RESPONSE_INIT_STATE'
-  | 'STATE_UPDATE'
-
-/**
- * Represents a message sent between stores.
- * @template T The type of the payload.
- * @remarks This interface is used for both sending and receiving messages between stores.
- **/
-export interface StoreBroadcastMessage<T> {
-  type: StoreBroadcastMessageType
-  senderId: string
-  payload: T
-}
+export type StoreBroadcastMessageType = StoreBroadcastMessage<unknown>['type']
 
 /**
  * Represents the status of the ChannelStore.
@@ -53,6 +60,15 @@ export type StoreStatusCallback = (status: StoreStatus) => void
  * Callback function type for store changes.
  */
 type StoreChangeCallback<T> = (value: T) => void
+
+interface LeaderLockHold {
+  readonly promise: Promise<void>
+  readonly release: () => void
+}
+
+interface MarkReadyOptions {
+  notifySubscribers: boolean
+}
 
 /**
  * Options for configuring a ChannelStore instance.
@@ -76,6 +92,24 @@ export interface ChannelStoreOptions<T> {
   initial: T
 }
 
+function createLeaderLockHold(): LeaderLockHold {
+  let release!: () => void
+
+  const promise = new Promise<void>((resolve) => {
+    release = resolve
+  })
+
+  return { promise, release }
+}
+
+function isAbortError(error: unknown): boolean {
+  return (
+    typeof DOMException !== 'undefined' &&
+    error instanceof DOMException &&
+    error.name === 'AbortError'
+  )
+}
+
 /**
  * A class that manages and shares state across different browser tabs or windows
  * using BroadcastChannel and IndexedDB for persistence.
@@ -94,9 +128,12 @@ export class ChannelStore<T> {
   private readonly _channel: BroadcastChannel
   private readonly _dbKey = 'state' // Fixed key for storing the single state object
   private readonly _prefixedName: string
-  private _instanceId: string
+  private readonly _instanceId = crypto.randomUUID()
   private _initialStateRequestTimeout: ReturnType<typeof setTimeout> | null =
     null
+  private readonly _leaderLockName: string
+  private _leaderLockHold: LeaderLockHold | null = null
+  private _waitToBecomeLeaderAbortController: AbortController | null = null
 
   /**
    * The current status of the store.
@@ -112,7 +149,7 @@ export class ChannelStore<T> {
     this._persist = options.persist ?? false
     this._initial = options.initial
     this._prefixedName = `channel-state__${this._name}`
-    this._instanceId = crypto.randomUUID()
+    this._leaderLockName = `${this._prefixedName}__leader`
 
     this._value = structuredClone(this._initial)
 
@@ -122,11 +159,11 @@ export class ChannelStore<T> {
     if (this._persist) {
       this._initDB()
     } else {
-      this._requestInitialStateFromOtherTabs()
+      this._initMemoryOnlyStore()
     }
   }
 
-  private _initDB() {
+  private _initDB(): void {
     if (this.status === 'destroyed') {
       return
     }
@@ -146,12 +183,11 @@ export class ChannelStore<T> {
 
     request.onerror = () => {
       console.error('IndexedDB init failed:', request.error)
-      this.status = 'ready' // Fallback to initial values cache
-      this._notifyStatusSubscribers()
+      this._markReady({ notifySubscribers: false }) // Fallback to initial values cache
     }
   }
 
-  private _loadCacheFromDB() {
+  private _loadCacheFromDB(): void {
     if (this.status === 'destroyed') {
       return
     }
@@ -169,17 +205,129 @@ export class ChannelStore<T> {
       if (val !== undefined) {
         this._value = val
       }
-      this.status = 'ready'
-      this._notifySubscribers()
-      this._notifyStatusSubscribers()
+      this._markReady({ notifySubscribers: true })
     }
     req.onerror = () => {
       // If IndexedDB read fails, request from other tabs
+      this._initMemoryOnlyStore()
+    }
+  }
+
+  private _initMemoryOnlyStore(): void {
+    if (this.status === 'destroyed') {
+      return
+    }
+
+    const lockManager = this._getLockManager()
+
+    if (lockManager === null) {
+      this._requestInitialStateFromOtherTabs()
+      return
+    }
+
+    try {
+      void lockManager
+        .request<Promise<boolean>>(
+          this._leaderLockName,
+          { ifAvailable: true },
+          async (lock) => {
+            if (this.status === 'destroyed' || lock === null) {
+              return false
+            }
+
+            await this._currentTabIsLeader()
+            return true
+          },
+        )
+        .then((acquiredLockPromise) => {
+          // Workaround for a TypeScript false positive that appears to be fixed in TS 6
+          const acquiredLock = acquiredLockPromise as unknown as boolean
+          if (this.status === 'destroyed' || acquiredLock) {
+            return
+          }
+
+          if (this.status === 'initializing') {
+            this._requestInitialStateFromOtherTabs()
+          }
+
+          this._waitToBecomeLeader(lockManager)
+        })
+        .catch((error: unknown) => {
+          if (this.status === 'destroyed' || isAbortError(error)) {
+            return
+          }
+
+          this._requestInitialStateFromOtherTabs()
+        })
+    } catch {
       this._requestInitialStateFromOtherTabs()
     }
   }
 
-  private _requestInitialStateFromOtherTabs() {
+  private _getLockManager(): LockManager | null {
+    if (
+      typeof navigator === 'undefined' ||
+      typeof navigator.locks === 'undefined'
+    ) {
+      return null
+    }
+
+    return navigator.locks
+  }
+
+  private _currentTabIsLeader(): Promise<void> {
+    const leaderLockHold = createLeaderLockHold()
+    this._leaderLockHold = leaderLockHold
+
+    this._markReady({ notifySubscribers: true })
+
+    return leaderLockHold.promise.finally(() => {
+      // Not leader anymore
+      if (this._leaderLockHold === leaderLockHold) {
+        this._leaderLockHold = null
+      }
+    })
+  }
+
+  private _waitToBecomeLeader(lockManager: LockManager): void {
+    if (
+      this.status === 'destroyed' ||
+      this._leaderLockHold !== null ||
+      this._waitToBecomeLeaderAbortController !== null
+    ) {
+      return
+    }
+
+    const abortController = new AbortController()
+    this._waitToBecomeLeaderAbortController = abortController
+
+    try {
+      void lockManager
+        .request<unknown>(
+          this._leaderLockName,
+          { signal: abortController.signal },
+          async (lock) => {
+            if (this.status === 'destroyed' || lock === null) {
+              return
+            }
+
+            this._waitToBecomeLeaderAbortController = null
+            await this._currentTabIsLeader()
+          },
+        )
+        .catch((error: unknown) => {
+          if (this.status === 'destroyed' || isAbortError(error)) {
+            return
+          }
+
+          this._waitToBecomeLeaderAbortController = null
+        })
+    } catch {
+      this._waitToBecomeLeaderAbortController = null
+    }
+  }
+
+  private _requestInitialStateFromOtherTabs(): void {
     if (this.status === 'destroyed') {
       return
     }
@@ -190,12 +338,53 @@ export class ChannelStore<T> {
 
     this._initialStateRequestTimeout = setTimeout(() => {
       if (this.status !== 'ready') {
-        this.status = 'ready'
-        this._notifySubscribers()
-        this._notifyStatusSubscribers()
+        this._markReady({ notifySubscribers: true })
       }
       this._initialStateRequestTimeout = null
-    }, 500) // Wait for 500ms for a response
+    }, 500) // Wait for 500ms for a response when another tab may exist or Web Locks are unavailable
+  }
+
+  private _clearInitialStateRequestTimeout(): void {
+    if (!this._initialStateRequestTimeout) {
+      return
+    }
+
+    clearTimeout(this._initialStateRequestTimeout)
+    this._initialStateRequestTimeout = null
+  }
+
+  private _markReady(options: MarkReadyOptions): void {
+    if (this.status !== 'initializing') {
+      return
+    }
+
+    this.status = 'ready'
+
+    if (options.notifySubscribers) {
+      this._notifySubscribers()
+    }
+
+    this._notifyStatusSubscribers()
+  }
+
+  private _shouldRespondToInitialStateRequest(): boolean {
+    if (this.status !== 'ready') {
+      return false
+    }
+
+    if (this._persist) {
+      return true
+    }
+
+    const lockManager = this._getLockManager()
+
+    // If locking isn't available, then always respond
+    if (lockManager === null) {
+      return true
+    }
+
+    // Only leader should respond
+    return this._leaderLockHold !== null
   }
 
   /**
@@ -210,7 +399,7 @@ export class ChannelStore<T> {
    */
   private _handleChannelMessage = (
     messageEvent: MessageEvent<StoreBroadcastMessage<T>>,
-  ) => {
+  ): void => {
     if (this.status === 'destroyed') {
       return
     }
@@ -223,24 +412,21 @@ export class ChannelStore<T> {
 
     switch (message.type) {
       case 'REQUEST_INIT_STATE':
-        this._channel.postMessage({
-          type: 'RESPONSE_INIT_STATE',
-          payload: this._value,
-          senderId: this._instanceId,
-        })
+        if (this._shouldRespondToInitialStateRequest()) {
+          this._channel.postMessage({
+            type: 'RESPONSE_INIT_STATE',
+            payload: this._value,
+            senderId: this._instanceId,
+          })
+        }
         break
 
       case 'RESPONSE_INIT_STATE':
         // Only accept this if we are still initializing
         if (this.status === 'initializing') {
-          if (this._initialStateRequestTimeout) {
-            clearTimeout(this._initialStateRequestTimeout)
-            this._initialStateRequestTimeout = null
-          }
+          this._clearInitialStateRequestTimeout()
           this._value = message.payload
-          this.status = 'ready'
-          this._notifySubscribers()
-          this._notifyStatusSubscribers()
+          this._markReady({ notifySubscribers: true })
         }
         break
 
@@ -258,13 +444,13 @@ export class ChannelStore<T> {
    * Notifies all registered subscribers about a change in the store's state.
    * @private
    */
-  private _notifySubscribers() {
+  private _notifySubscribers(): void {
     this._subscribers.forEach((subscriber) => {
       subscriber(this._value)
     })
   }
 
-  private _notifyStatusSubscribers() {
+  private _notifyStatusSubscribers(): void {
     this._statusSubscribers.forEach((subscriber) => {
       subscriber(this.status)
     })
@@ -275,7 +461,7 @@ export class ChannelStore<T> {
    * and notifying local subscribers.
    * @private
    */
-  private _triggerChange() {
+  private _triggerChange(): void {
     if (this.status === 'destroyed') {
       return
     }
@@ -313,8 +499,8 @@ export class ChannelStore<T> {
     }
 
     if (this.status === 'initializing') {
-      this.status = 'ready'
-      this._notifyStatusSubscribers()
+      this._clearInitialStateRequestTimeout()
+      this._markReady({ notifySubscribers: false })
     }
 
     this._value = value
@@ -382,19 +568,27 @@ export class ChannelStore<T> {
    * Cleans up resources used by the ChannelStore, including closing the BroadcastChannel
    * and IndexedDB connection, and clearing subscribers.
    */
-  destroy() {
+  destroy(): void {
     if (this.status === 'destroyed') {
       return
     }
     this.status = 'destroyed'
     this._notifyStatusSubscribers()
+    this._channel.removeEventListener('message', this._handleChannelMessage)
     this._channel.close()
     this._subscribers.clear()
     this._statusSubscribers.clear()
     this._db?.close()
-    if (this._initialStateRequestTimeout) {
-      clearTimeout(this._initialStateRequestTimeout)
-      this._initialStateRequestTimeout = null
+    this._clearInitialStateRequestTimeout()
+
+    if (this._waitToBecomeLeaderAbortController) {
+      this._waitToBecomeLeaderAbortController.abort()
+      this._waitToBecomeLeaderAbortController = null
+    }
+
+    if (this._leaderLockHold) {
+      this._leaderLockHold.release()
+      this._leaderLockHold = null
     }
   }
 
@@ -423,7 +617,7 @@ export class ChannelStore<T> {
 
       const tx = db.transaction(this._prefixedName, 'readwrite')
       const store = tx.objectStore(this._prefixedName)
-      const req = store.put(this._initial, this._dbKey)
+      const req = store.put(this._value, this._dbKey)
 
       req.onsuccess = () => {
         this._triggerChange()

--- a/packages/core/src/ChannelState.ts
+++ b/packages/core/src/ChannelState.ts
@@ -61,11 +61,6 @@ export type StoreStatusCallback = (status: StoreStatus) => void
  */
 type StoreChangeCallback<T> = (value: T) => void
 
-interface LeaderLockHold {
-  readonly promise: Promise<void>
-  readonly release: () => void
-}
-
 interface MarkReadyOptions {
   notifySubscribers: boolean
 }
@@ -92,22 +87,24 @@ export interface ChannelStoreOptions<T> {
   initial: T
 }
 
-function createLeaderLockHold(): LeaderLockHold {
-  let release!: () => void
-
-  const promise = new Promise<void>((resolve) => {
-    release = resolve
-  })
-
-  return { promise, release }
-}
-
 function isAbortError(error: unknown): boolean {
   return (
     typeof DOMException !== 'undefined' &&
     error instanceof DOMException &&
     error.name === 'AbortError'
   )
+}
+
+function promisifyIDBRequest<T>(request: IDBRequest<T>): Promise<T> {
+  return new Promise<T>((resolve, reject) => {
+    request.onsuccess = () => {
+      resolve(request.result)
+    }
+
+    request.onerror = () => {
+      reject(new Error(request.error?.message ?? 'unknown error'))
+    }
+  })
 }
 
 /**
@@ -132,7 +129,7 @@ export class ChannelStore<T> {
   private _initialStateRequestTimeout: ReturnType<typeof setTimeout> | null =
     null
   private readonly _leaderLockName: string
-  private _leaderLockHold: LeaderLockHold | null = null
+  private _leaderLockHold: PromiseWithResolvers<void> | null = null
   private _waitToBecomeLeaderAbortController: AbortController | null = null
 
   /**
@@ -159,7 +156,7 @@ export class ChannelStore<T> {
     if (this._persist) {
       this._initDB()
     } else {
-      this._initMemoryOnlyStore()
+      void this._initMemoryOnlyStore()
     }
   }
 
@@ -209,12 +206,19 @@ export class ChannelStore<T> {
     }
     req.onerror = () => {
       // If IndexedDB read fails, request from other tabs
-      this._initMemoryOnlyStore()
+      void this._initMemoryOnlyStore()
     }
   }
 
-  private _initMemoryOnlyStore(): void {
-    if (this.status === 'destroyed') {
+  private async _initMemoryOnlyStore(): Promise<void> {
+    const checkDestroyed = () => {
+      if (this.status === 'destroyed') {
+        return true
+      }
+      return false
+    }
+
+    if (checkDestroyed()) {
       return
     }
 
@@ -226,40 +230,33 @@ export class ChannelStore<T> {
     }
 
     try {
-      void lockManager
-        .request<Promise<boolean>>(
-          this._leaderLockName,
-          { ifAvailable: true },
-          async (lock) => {
-            if (this.status === 'destroyed' || lock === null) {
-              return false
-            }
-
-            await this._currentTabIsLeader()
-            return true
-          },
-        )
-        .then((acquiredLockPromise) => {
-          // Workaround for a TypeScript false positive that appears to be fixed in TS 6
-          const acquiredLock = acquiredLockPromise as unknown as boolean
-          if (this.status === 'destroyed' || acquiredLock) {
-            return
+      const acquiredLock = await lockManager.request<Promise<boolean>>(
+        this._leaderLockName,
+        { ifAvailable: true },
+        async (lock) => {
+          if (this.status === 'destroyed' || lock === null) {
+            return false
           }
 
-          if (this.status === 'initializing') {
-            this._requestInitialStateFromOtherTabs()
-          }
+          await this._currentTabIsLeader()
+          return true
+        },
+      )
 
-          this._waitToBecomeLeader(lockManager)
-        })
-        .catch((error: unknown) => {
-          if (this.status === 'destroyed' || isAbortError(error)) {
-            return
-          }
+      if (this.status === 'destroyed' || acquiredLock) {
+        return
+      }
 
-          this._requestInitialStateFromOtherTabs()
-        })
-    } catch {
+      if (this.status === 'initializing') {
+        this._requestInitialStateFromOtherTabs()
+      }
+
+      void this._waitToBecomeLeader(lockManager)
+    } catch (error: unknown) {
+      if (this.status === 'destroyed' || isAbortError(error)) {
+        return
+      }
+
       this._requestInitialStateFromOtherTabs()
     }
   }
@@ -276,7 +273,7 @@ export class ChannelStore<T> {
   }
 
   private _currentTabIsLeader(): Promise<void> {
-    const leaderLockHold = createLeaderLockHold()
+    const leaderLockHold: PromiseWithResolvers<void> = Promise.withResolvers()
     this._leaderLockHold = leaderLockHold
 
     this._markReady({ notifySubscribers: true })
@@ -289,12 +286,13 @@ export class ChannelStore<T> {
     })
   }
 
-  private _waitToBecomeLeader(lockManager: LockManager): void {
-    if (
+  private async _waitToBecomeLeader(lockManager: LockManager): Promise<void> {
+    const shouldSkipWaiting =
       this.status === 'destroyed' ||
       this._leaderLockHold !== null ||
       this._waitToBecomeLeaderAbortController !== null
-    ) {
+
+    if (shouldSkipWaiting) {
       return
     }
 
@@ -302,27 +300,23 @@ export class ChannelStore<T> {
     this._waitToBecomeLeaderAbortController = abortController
 
     try {
-      void lockManager
-        .request<unknown>(
-          this._leaderLockName,
-          { signal: abortController.signal },
-          async (lock) => {
-            if (this.status === 'destroyed' || lock === null) {
-              return
-            }
-
-            this._waitToBecomeLeaderAbortController = null
-            await this._currentTabIsLeader()
-          },
-        )
-        .catch((error: unknown) => {
-          if (this.status === 'destroyed' || isAbortError(error)) {
+      await lockManager.request<Promise<void>>(
+        this._leaderLockName,
+        { signal: abortController.signal },
+        async (lock) => {
+          if (this.status === 'destroyed' || lock === null) {
             return
           }
 
           this._waitToBecomeLeaderAbortController = null
-        })
-    } catch {
+          await this._currentTabIsLeader()
+        },
+      )
+    } catch (error: unknown) {
+      if (this.status === 'destroyed' || isAbortError(error)) {
+        return
+      }
+
       this._waitToBecomeLeaderAbortController = null
     }
   }
@@ -473,6 +467,20 @@ export class ChannelStore<T> {
     this._notifySubscribers()
   }
 
+  private async _persistValue(value: T): Promise<void> {
+    const db = this._db
+
+    if (!db) {
+      throw new Error('Database not initialized')
+    }
+
+    const tx = db.transaction(this._prefixedName, 'readwrite')
+    const store = tx.objectStore(this._prefixedName)
+    const req = store.put(value, this._dbKey)
+
+    await promisifyIDBRequest(req)
+  }
+
   /**
    * Synchronously retrieves the current state from the cache.
    * @returns The current state of the store.
@@ -510,26 +518,13 @@ export class ChannelStore<T> {
       return
     }
 
-    void new Promise<void>((resolve, reject) => {
-      const db = this._db
-
-      if (!db) {
-        reject(new Error('Database not initialized'))
-        return
-      }
-
-      const tx = db.transaction(this._prefixedName, 'readwrite')
-      const store = tx.objectStore(this._prefixedName)
-      const req = store.put(value, this._dbKey)
-
-      req.onsuccess = () => {
+    void this._persistValue(value)
+      .then(() => {
         this._triggerChange()
-        resolve()
-      }
-      req.onerror = () => {
-        reject(new Error(req.error?.message ?? 'unknown error'))
-      }
-    })
+      })
+      .catch((error: unknown) => {
+        console.error('IndexedDB write failed:', error)
+      })
   }
 
   /**
@@ -587,7 +582,7 @@ export class ChannelStore<T> {
     }
 
     if (this._leaderLockHold) {
-      this._leaderLockHold.release()
+      this._leaderLockHold.resolve()
       this._leaderLockHold = null
     }
   }
@@ -596,36 +591,18 @@ export class ChannelStore<T> {
    * Resets the store's state to its initial value.
    * @returns A Promise that resolves when the state has been reset.
    */
-  reset(): Promise<void> {
+  async reset(): Promise<void> {
     if (this.status === 'destroyed') {
-      return Promise.resolve()
+      return
     }
     this._value = structuredClone(this._initial)
 
     if (!this._db) {
       this._triggerChange()
-      return Promise.resolve()
+      return
     }
 
-    return new Promise((resolve, reject) => {
-      const db = this._db
-
-      if (!db) {
-        reject(new Error('IndexedDB is not available'))
-        return
-      }
-
-      const tx = db.transaction(this._prefixedName, 'readwrite')
-      const store = tx.objectStore(this._prefixedName)
-      const req = store.put(this._value, this._dbKey)
-
-      req.onsuccess = () => {
-        this._triggerChange()
-        resolve()
-      }
-      req.onerror = () => {
-        reject(new Error(req.error?.message ?? 'unknown error'))
-      }
-    })
+    await this._persistValue(this._value)
+    this._triggerChange()
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -22,16 +22,16 @@ importers:
         version: 20.19.1
       '@typescript-eslint/eslint-plugin':
         specifier: ^8.35.1
-        version: 8.35.1(@typescript-eslint/parser@8.35.1(eslint@9.30.1)(typescript@5.8.3))(eslint@9.30.1)(typescript@5.8.3)
+        version: 8.35.1(@typescript-eslint/parser@8.35.1(eslint@9.30.1)(typescript@5.9.3))(eslint@9.30.1)(typescript@5.9.3)
       '@typescript-eslint/parser':
         specifier: ^8.35.1
-        version: 8.35.1(eslint@9.30.1)(typescript@5.8.3)
+        version: 8.35.1(eslint@9.30.1)(typescript@5.9.3)
       '@vitejs/plugin-react':
         specifier: ^4.0.0
         version: 4.6.0(vite@6.3.5(@types/node@20.19.1)(yaml@2.8.0))
       '@vitejs/plugin-vue':
         specifier: ^5.0.0
-        version: 5.2.4(vite@6.3.5(@types/node@20.19.1)(yaml@2.8.0))(vue@3.5.17(typescript@5.8.3))
+        version: 5.2.4(vite@6.3.5(@types/node@20.19.1)(yaml@2.8.0))(vue@3.5.17(typescript@5.9.3))
       '@vitest/coverage-v8':
         specifier: ^3.2.4
         version: 3.2.4(vitest@3.2.4(@types/node@20.19.1)(jsdom@26.1.0)(yaml@2.8.0))
@@ -52,10 +52,10 @@ importers:
         version: 5.5.1(eslint-config-prettier@10.1.5(eslint@9.30.1))(eslint@9.30.1)(prettier@3.6.2)
       eslint-plugin-svelte:
         specifier: ^3.11.0
-        version: 3.11.0(eslint@9.30.1)(svelte@5.34.8)(ts-node@10.9.2(@types/node@20.19.1)(typescript@5.8.3))
+        version: 3.11.0(eslint@9.30.1)(svelte@5.34.8)(ts-node@10.9.2(@types/node@20.19.1)(typescript@5.9.3))
       eslint-plugin-vue:
         specifier: ^10.3.0
-        version: 10.3.0(@typescript-eslint/parser@8.35.1(eslint@9.30.1)(typescript@5.8.3))(eslint@9.30.1)(vue-eslint-parser@10.2.0(eslint@9.30.1))
+        version: 10.3.0(@typescript-eslint/parser@8.35.1(eslint@9.30.1)(typescript@5.9.3))(eslint@9.30.1)(vue-eslint-parser@10.2.0(eslint@9.30.1))
       globals:
         specifier: ^16.3.0
         version: 16.3.0
@@ -82,16 +82,16 @@ importers:
         version: 1.3.0(svelte@5.34.8)
       ts-node:
         specifier: ^10.9.2
-        version: 10.9.2(@types/node@20.19.1)(typescript@5.8.3)
+        version: 10.9.2(@types/node@20.19.1)(typescript@5.9.3)
       tsup:
         specifier: ^8.0.0
-        version: 8.5.0(postcss@8.5.6)(typescript@5.8.3)(yaml@2.8.0)
+        version: 8.5.0(postcss@8.5.6)(typescript@5.9.3)(yaml@2.8.0)
       typescript:
-        specifier: ^5.0.0
-        version: 5.8.3
+        specifier: ^5.9.3
+        version: 5.9.3
       typescript-eslint:
         specifier: ^8.35.1
-        version: 8.35.1(eslint@9.30.1)(typescript@5.8.3)
+        version: 8.35.1(eslint@9.30.1)(typescript@5.9.3)
       vite:
         specifier: ^6.0.0
         version: 6.3.5(@types/node@20.19.1)(yaml@2.8.0)
@@ -174,14 +174,14 @@ importers:
         version: link:../../packages/vue
       vue:
         specifier: ^3.4.21
-        version: 3.5.17(typescript@5.8.3)
+        version: 3.5.17(typescript@5.9.3)
     devDependencies:
       '@vitejs/plugin-vue':
         specifier: ^6.0.0
-        version: 6.0.0(vite@6.3.5(@types/node@20.19.1)(yaml@2.8.0))(vue@3.5.17(typescript@5.8.3))
+        version: 6.0.0(vite@6.3.5(@types/node@20.19.1)(yaml@2.8.0))(vue@3.5.17(typescript@5.9.3))
       vue-tsc:
         specifier: ^2.0.11
-        version: 2.2.12(typescript@5.8.3)
+        version: 2.2.12(typescript@5.9.3)
 
   packages/core: {}
 
@@ -228,13 +228,13 @@ importers:
         version: link:../core
       '@types/vue':
         specifier: ^2.0.0
-        version: 2.0.0(typescript@5.8.3)
+        version: 2.0.0(typescript@5.9.3)
       '@vue/test-utils':
         specifier: ^2.4.6
         version: 2.4.6
       vue:
         specifier: ^3.4.21
-        version: 3.5.17(typescript@5.8.3)
+        version: 3.5.17(typescript@5.9.3)
 
 packages:
 
@@ -2655,6 +2655,11 @@ packages:
     engines: {node: '>=14.17'}
     hasBin: true
 
+  typescript@5.9.3:
+    resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
+    engines: {node: '>=14.17'}
+    hasBin: true
+
   ufo@1.6.1:
     resolution: {integrity: sha512-9a4/uxlTWJ4+a5i0ooc1rU7C7YOw3wT+UGqdeNNHWnOF9qcMBgLRS+4IYUqbczewFx4mLEig6gawh7X6mFlEkA==}
 
@@ -3434,47 +3439,47 @@ snapshots:
       '@types/prop-types': 15.7.15
       csstype: 3.1.3
 
-  '@types/vue@2.0.0(typescript@5.8.3)':
+  '@types/vue@2.0.0(typescript@5.9.3)':
     dependencies:
-      vue: 3.5.17(typescript@5.8.3)
+      vue: 3.5.17(typescript@5.9.3)
     transitivePeerDependencies:
       - typescript
 
-  '@typescript-eslint/eslint-plugin@8.35.1(@typescript-eslint/parser@8.35.1(eslint@9.30.1)(typescript@5.8.3))(eslint@9.30.1)(typescript@5.8.3)':
+  '@typescript-eslint/eslint-plugin@8.35.1(@typescript-eslint/parser@8.35.1(eslint@9.30.1)(typescript@5.9.3))(eslint@9.30.1)(typescript@5.9.3)':
     dependencies:
       '@eslint-community/regexpp': 4.12.1
-      '@typescript-eslint/parser': 8.35.1(eslint@9.30.1)(typescript@5.8.3)
+      '@typescript-eslint/parser': 8.35.1(eslint@9.30.1)(typescript@5.9.3)
       '@typescript-eslint/scope-manager': 8.35.1
-      '@typescript-eslint/type-utils': 8.35.1(eslint@9.30.1)(typescript@5.8.3)
-      '@typescript-eslint/utils': 8.35.1(eslint@9.30.1)(typescript@5.8.3)
+      '@typescript-eslint/type-utils': 8.35.1(eslint@9.30.1)(typescript@5.9.3)
+      '@typescript-eslint/utils': 8.35.1(eslint@9.30.1)(typescript@5.9.3)
       '@typescript-eslint/visitor-keys': 8.35.1
       eslint: 9.30.1
       graphemer: 1.4.0
       ignore: 7.0.5
       natural-compare: 1.4.0
-      ts-api-utils: 2.1.0(typescript@5.8.3)
-      typescript: 5.8.3
+      ts-api-utils: 2.1.0(typescript@5.9.3)
+      typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/parser@8.35.1(eslint@9.30.1)(typescript@5.8.3)':
+  '@typescript-eslint/parser@8.35.1(eslint@9.30.1)(typescript@5.9.3)':
     dependencies:
       '@typescript-eslint/scope-manager': 8.35.1
       '@typescript-eslint/types': 8.35.1
-      '@typescript-eslint/typescript-estree': 8.35.1(typescript@5.8.3)
+      '@typescript-eslint/typescript-estree': 8.35.1(typescript@5.9.3)
       '@typescript-eslint/visitor-keys': 8.35.1
       debug: 4.4.1
       eslint: 9.30.1
-      typescript: 5.8.3
+      typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/project-service@8.35.1(typescript@5.8.3)':
+  '@typescript-eslint/project-service@8.35.1(typescript@5.9.3)':
     dependencies:
-      '@typescript-eslint/tsconfig-utils': 8.35.1(typescript@5.8.3)
+      '@typescript-eslint/tsconfig-utils': 8.35.1(typescript@5.9.3)
       '@typescript-eslint/types': 8.35.1
       debug: 4.4.1
-      typescript: 5.8.3
+      typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
 
@@ -3483,27 +3488,27 @@ snapshots:
       '@typescript-eslint/types': 8.35.1
       '@typescript-eslint/visitor-keys': 8.35.1
 
-  '@typescript-eslint/tsconfig-utils@8.35.1(typescript@5.8.3)':
+  '@typescript-eslint/tsconfig-utils@8.35.1(typescript@5.9.3)':
     dependencies:
-      typescript: 5.8.3
+      typescript: 5.9.3
 
-  '@typescript-eslint/type-utils@8.35.1(eslint@9.30.1)(typescript@5.8.3)':
+  '@typescript-eslint/type-utils@8.35.1(eslint@9.30.1)(typescript@5.9.3)':
     dependencies:
-      '@typescript-eslint/typescript-estree': 8.35.1(typescript@5.8.3)
-      '@typescript-eslint/utils': 8.35.1(eslint@9.30.1)(typescript@5.8.3)
+      '@typescript-eslint/typescript-estree': 8.35.1(typescript@5.9.3)
+      '@typescript-eslint/utils': 8.35.1(eslint@9.30.1)(typescript@5.9.3)
       debug: 4.4.1
       eslint: 9.30.1
-      ts-api-utils: 2.1.0(typescript@5.8.3)
-      typescript: 5.8.3
+      ts-api-utils: 2.1.0(typescript@5.9.3)
+      typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
 
   '@typescript-eslint/types@8.35.1': {}
 
-  '@typescript-eslint/typescript-estree@8.35.1(typescript@5.8.3)':
+  '@typescript-eslint/typescript-estree@8.35.1(typescript@5.9.3)':
     dependencies:
-      '@typescript-eslint/project-service': 8.35.1(typescript@5.8.3)
-      '@typescript-eslint/tsconfig-utils': 8.35.1(typescript@5.8.3)
+      '@typescript-eslint/project-service': 8.35.1(typescript@5.9.3)
+      '@typescript-eslint/tsconfig-utils': 8.35.1(typescript@5.9.3)
       '@typescript-eslint/types': 8.35.1
       '@typescript-eslint/visitor-keys': 8.35.1
       debug: 4.4.1
@@ -3511,19 +3516,19 @@ snapshots:
       is-glob: 4.0.3
       minimatch: 9.0.5
       semver: 7.7.2
-      ts-api-utils: 2.1.0(typescript@5.8.3)
-      typescript: 5.8.3
+      ts-api-utils: 2.1.0(typescript@5.9.3)
+      typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/utils@8.35.1(eslint@9.30.1)(typescript@5.8.3)':
+  '@typescript-eslint/utils@8.35.1(eslint@9.30.1)(typescript@5.9.3)':
     dependencies:
       '@eslint-community/eslint-utils': 4.7.0(eslint@9.30.1)
       '@typescript-eslint/scope-manager': 8.35.1
       '@typescript-eslint/types': 8.35.1
-      '@typescript-eslint/typescript-estree': 8.35.1(typescript@5.8.3)
+      '@typescript-eslint/typescript-estree': 8.35.1(typescript@5.9.3)
       eslint: 9.30.1
-      typescript: 5.8.3
+      typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
 
@@ -3544,16 +3549,16 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@vitejs/plugin-vue@5.2.4(vite@6.3.5(@types/node@20.19.1)(yaml@2.8.0))(vue@3.5.17(typescript@5.8.3))':
+  '@vitejs/plugin-vue@5.2.4(vite@6.3.5(@types/node@20.19.1)(yaml@2.8.0))(vue@3.5.17(typescript@5.9.3))':
     dependencies:
       vite: 6.3.5(@types/node@20.19.1)(yaml@2.8.0)
-      vue: 3.5.17(typescript@5.8.3)
+      vue: 3.5.17(typescript@5.9.3)
 
-  '@vitejs/plugin-vue@6.0.0(vite@6.3.5(@types/node@20.19.1)(yaml@2.8.0))(vue@3.5.17(typescript@5.8.3))':
+  '@vitejs/plugin-vue@6.0.0(vite@6.3.5(@types/node@20.19.1)(yaml@2.8.0))(vue@3.5.17(typescript@5.9.3))':
     dependencies:
       '@rolldown/pluginutils': 1.0.0-beta.19
       vite: 6.3.5(@types/node@20.19.1)(yaml@2.8.0)
-      vue: 3.5.17(typescript@5.8.3)
+      vue: 3.5.17(typescript@5.9.3)
 
   '@vitest/coverage-v8@3.2.4(vitest@3.2.4(@types/node@20.19.1)(jsdom@26.1.0)(yaml@2.8.0))':
     dependencies:
@@ -3663,7 +3668,7 @@ snapshots:
       de-indent: 1.0.2
       he: 1.2.0
 
-  '@vue/language-core@2.2.12(typescript@5.8.3)':
+  '@vue/language-core@2.2.12(typescript@5.9.3)':
     dependencies:
       '@volar/language-core': 2.4.15
       '@vue/compiler-dom': 3.5.17
@@ -3674,7 +3679,7 @@ snapshots:
       muggle-string: 0.4.1
       path-browserify: 1.0.1
     optionalDependencies:
-      typescript: 5.8.3
+      typescript: 5.9.3
 
   '@vue/reactivity@3.5.17':
     dependencies:
@@ -3692,11 +3697,11 @@ snapshots:
       '@vue/shared': 3.5.17
       csstype: 3.1.3
 
-  '@vue/server-renderer@3.5.17(vue@3.5.17(typescript@5.8.3))':
+  '@vue/server-renderer@3.5.17(vue@3.5.17(typescript@5.9.3))':
     dependencies:
       '@vue/compiler-ssr': 3.5.17
       '@vue/shared': 3.5.17
-      vue: 3.5.17(typescript@5.8.3)
+      vue: 3.5.17(typescript@5.9.3)
 
   '@vue/shared@3.5.17': {}
 
@@ -4101,7 +4106,7 @@ snapshots:
     optionalDependencies:
       eslint-config-prettier: 10.1.5(eslint@9.30.1)
 
-  eslint-plugin-svelte@3.11.0(eslint@9.30.1)(svelte@5.34.8)(ts-node@10.9.2(@types/node@20.19.1)(typescript@5.8.3)):
+  eslint-plugin-svelte@3.11.0(eslint@9.30.1)(svelte@5.34.8)(ts-node@10.9.2(@types/node@20.19.1)(typescript@5.9.3)):
     dependencies:
       '@eslint-community/eslint-utils': 4.7.0(eslint@9.30.1)
       '@jridgewell/sourcemap-codec': 1.5.0
@@ -4110,7 +4115,7 @@ snapshots:
       globals: 16.3.0
       known-css-properties: 0.37.0
       postcss: 8.5.6
-      postcss-load-config: 3.1.4(postcss@8.5.6)(ts-node@10.9.2(@types/node@20.19.1)(typescript@5.8.3))
+      postcss-load-config: 3.1.4(postcss@8.5.6)(ts-node@10.9.2(@types/node@20.19.1)(typescript@5.9.3))
       postcss-safe-parser: 7.0.1(postcss@8.5.6)
       semver: 7.7.2
       svelte-eslint-parser: 1.3.0(svelte@5.34.8)
@@ -4119,7 +4124,7 @@ snapshots:
     transitivePeerDependencies:
       - ts-node
 
-  eslint-plugin-vue@10.3.0(@typescript-eslint/parser@8.35.1(eslint@9.30.1)(typescript@5.8.3))(eslint@9.30.1)(vue-eslint-parser@10.2.0(eslint@9.30.1)):
+  eslint-plugin-vue@10.3.0(@typescript-eslint/parser@8.35.1(eslint@9.30.1)(typescript@5.9.3))(eslint@9.30.1)(vue-eslint-parser@10.2.0(eslint@9.30.1)):
     dependencies:
       '@eslint-community/eslint-utils': 4.7.0(eslint@9.30.1)
       eslint: 9.30.1
@@ -4130,7 +4135,7 @@ snapshots:
       vue-eslint-parser: 10.2.0(eslint@9.30.1)
       xml-name-validator: 4.0.0
     optionalDependencies:
-      '@typescript-eslint/parser': 8.35.1(eslint@9.30.1)(typescript@5.8.3)
+      '@typescript-eslint/parser': 8.35.1(eslint@9.30.1)(typescript@5.9.3)
 
   eslint-scope@8.4.0:
     dependencies:
@@ -4860,6 +4865,15 @@ snapshots:
     optionalDependencies:
       postcss: 8.5.6
       ts-node: 10.9.2(@types/node@20.19.1)(typescript@5.8.3)
+    optional: true
+
+  postcss-load-config@3.1.4(postcss@8.5.6)(ts-node@10.9.2(@types/node@20.19.1)(typescript@5.9.3)):
+    dependencies:
+      lilconfig: 2.1.0
+      yaml: 1.10.2
+    optionalDependencies:
+      postcss: 8.5.6
+      ts-node: 10.9.2(@types/node@20.19.1)(typescript@5.9.3)
 
   postcss-load-config@6.0.1(postcss@8.5.6)(yaml@2.8.0):
     dependencies:
@@ -5180,8 +5194,8 @@ snapshots:
       picocolors: 1.1.1
       sade: 1.8.1
       svelte: 5.34.8
-      svelte-preprocess: 5.1.4(@babel/core@7.27.7)(postcss-load-config@3.1.4(postcss@8.5.6)(ts-node@10.9.2(@types/node@20.19.1)(typescript@5.8.3)))(postcss@8.5.6)(svelte@5.34.8)(typescript@5.8.3)
-      typescript: 5.8.3
+      svelte-preprocess: 5.1.4(@babel/core@7.27.7)(postcss-load-config@3.1.4(postcss@8.5.6)(ts-node@10.9.2(@types/node@20.19.1)(typescript@5.8.3)))(postcss@8.5.6)(svelte@5.34.8)(typescript@5.9.3)
+      typescript: 5.9.3
     transitivePeerDependencies:
       - '@babel/core'
       - coffeescript
@@ -5204,7 +5218,7 @@ snapshots:
     optionalDependencies:
       svelte: 5.34.8
 
-  svelte-preprocess@5.1.4(@babel/core@7.27.7)(postcss-load-config@3.1.4(postcss@8.5.6)(ts-node@10.9.2(@types/node@20.19.1)(typescript@5.8.3)))(postcss@8.5.6)(svelte@5.34.8)(typescript@5.8.3):
+  svelte-preprocess@5.1.4(@babel/core@7.27.7)(postcss-load-config@3.1.4(postcss@8.5.6)(ts-node@10.9.2(@types/node@20.19.1)(typescript@5.8.3)))(postcss@8.5.6)(svelte@5.34.8)(typescript@5.9.3):
     dependencies:
       '@types/pug': 2.0.10
       detect-indent: 6.1.0
@@ -5216,7 +5230,7 @@ snapshots:
       '@babel/core': 7.27.7
       postcss: 8.5.6
       postcss-load-config: 3.1.4(postcss@8.5.6)(ts-node@10.9.2(@types/node@20.19.1)(typescript@5.8.3))
-      typescript: 5.8.3
+      typescript: 5.9.3
 
   svelte@5.34.8:
     dependencies:
@@ -5294,9 +5308,9 @@ snapshots:
 
   tree-kill@1.2.2: {}
 
-  ts-api-utils@2.1.0(typescript@5.8.3):
+  ts-api-utils@2.1.0(typescript@5.9.3):
     dependencies:
-      typescript: 5.8.3
+      typescript: 5.9.3
 
   ts-interface-checker@0.1.13: {}
 
@@ -5317,10 +5331,29 @@ snapshots:
       typescript: 5.8.3
       v8-compile-cache-lib: 3.0.1
       yn: 3.1.1
+    optional: true
+
+  ts-node@10.9.2(@types/node@20.19.1)(typescript@5.9.3):
+    dependencies:
+      '@cspotcode/source-map-support': 0.8.1
+      '@tsconfig/node10': 1.0.11
+      '@tsconfig/node12': 1.0.11
+      '@tsconfig/node14': 1.0.3
+      '@tsconfig/node16': 1.0.4
+      '@types/node': 20.19.1
+      acorn: 8.15.0
+      acorn-walk: 8.3.4
+      arg: 4.1.3
+      create-require: 1.1.1
+      diff: 4.0.2
+      make-error: 1.3.6
+      typescript: 5.9.3
+      v8-compile-cache-lib: 3.0.1
+      yn: 3.1.1
 
   tslib@2.8.1: {}
 
-  tsup@8.5.0(postcss@8.5.6)(typescript@5.8.3)(yaml@2.8.0):
+  tsup@8.5.0(postcss@8.5.6)(typescript@5.9.3)(yaml@2.8.0):
     dependencies:
       bundle-require: 5.1.0(esbuild@0.25.5)
       cac: 6.7.14
@@ -5341,7 +5374,7 @@ snapshots:
       tree-kill: 1.2.2
     optionalDependencies:
       postcss: 8.5.6
-      typescript: 5.8.3
+      typescript: 5.9.3
     transitivePeerDependencies:
       - jiti
       - supports-color
@@ -5352,17 +5385,19 @@ snapshots:
     dependencies:
       prelude-ls: 1.2.1
 
-  typescript-eslint@8.35.1(eslint@9.30.1)(typescript@5.8.3):
+  typescript-eslint@8.35.1(eslint@9.30.1)(typescript@5.9.3):
     dependencies:
-      '@typescript-eslint/eslint-plugin': 8.35.1(@typescript-eslint/parser@8.35.1(eslint@9.30.1)(typescript@5.8.3))(eslint@9.30.1)(typescript@5.8.3)
-      '@typescript-eslint/parser': 8.35.1(eslint@9.30.1)(typescript@5.8.3)
-      '@typescript-eslint/utils': 8.35.1(eslint@9.30.1)(typescript@5.8.3)
+      '@typescript-eslint/eslint-plugin': 8.35.1(@typescript-eslint/parser@8.35.1(eslint@9.30.1)(typescript@5.9.3))(eslint@9.30.1)(typescript@5.9.3)
+      '@typescript-eslint/parser': 8.35.1(eslint@9.30.1)(typescript@5.9.3)
+      '@typescript-eslint/utils': 8.35.1(eslint@9.30.1)(typescript@5.9.3)
       eslint: 9.30.1
-      typescript: 5.8.3
+      typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
 
   typescript@5.8.3: {}
+
+  typescript@5.9.3: {}
 
   ufo@1.6.1: {}
 
@@ -5478,21 +5513,21 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  vue-tsc@2.2.12(typescript@5.8.3):
+  vue-tsc@2.2.12(typescript@5.9.3):
     dependencies:
       '@volar/typescript': 2.4.15
-      '@vue/language-core': 2.2.12(typescript@5.8.3)
-      typescript: 5.8.3
+      '@vue/language-core': 2.2.12(typescript@5.9.3)
+      typescript: 5.9.3
 
-  vue@3.5.17(typescript@5.8.3):
+  vue@3.5.17(typescript@5.9.3):
     dependencies:
       '@vue/compiler-dom': 3.5.17
       '@vue/compiler-sfc': 3.5.17
       '@vue/runtime-dom': 3.5.17
-      '@vue/server-renderer': 3.5.17(vue@3.5.17(typescript@5.8.3))
+      '@vue/server-renderer': 3.5.17(vue@3.5.17(typescript@5.9.3))
       '@vue/shared': 3.5.17
     optionalDependencies:
-      typescript: 5.8.3
+      typescript: 5.9.3
 
   w3c-xmlserializer@5.0.0:
     dependencies:

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "target": "ES2020",
-    "lib": ["ES2020", "DOM", "DOM.Iterable"],
+    "lib": ["ESNext", "DOM", "DOM.Iterable"],
     "module": "ESNext",
     "skipLibCheck": true,
     "moduleResolution": "bundler",


### PR DESCRIPTION
## Description

Currently, if persistence is deactivated, there is a hard-coded time frame of 500 ms during which the library waits for a potential response from other tabs. Furthermore, if multiple tabs exist, all of them answer the init request.

This pull request does the following:
1. It introduces the use of the Web Locks API for leader election. This way, the tab always knows whether it is the only tab or whether it must send an init request for initialization.
2. Only the leader tab answers init requests.
3. If the leader tab disappears, a new tab is elected as the leader, if any other tabs exist.
4. If the Web Locks API is not available, it falls back to waiting for 500ms. We can probably skip this because of the broad support for the Web Locks API: https://caniuse.com/mdn-api_lock

Fixes #48

## Related Package

@channel-state/core

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

- [x] Manually tested in Chrome
- [x] Added new tests

## Browser Compatibility

Uses the Web Locks API, but has a fallback.

## Dependencies

-

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [!] My changes generate no new warnings: There seems to be a bug in TS < 6, see comment in code.
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass successfully with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
